### PR TITLE
Add a (tall) option on example media containers - max height 1200px

### DIFF
--- a/blocks/example/example.css
+++ b/blocks/example/example.css
@@ -218,3 +218,16 @@ main .descr-details .video-holder {
 .descr-details .text-blue { color: #31A8FF; }
 .descr-details .text-yellow { color: #FFC857; }
 .descr-details .text-green { color: #15A46E; }
+
+.descr-details-gray-container.tall-example picture img,
+.descr-details-gray-container.tall-example video,
+.descr-details-gray-container.tall-example .example-media-row picture img,
+.descr-details-gray-container.tall-example .example-media-row .descr-details-video video {
+  height: auto;
+  width: 100%;
+  max-height: 1200px;
+}
+
+.descr-details-gray-container.tall-example .example-media-row .descr-details-video .video-holder {
+  max-height: 1200px;
+}

--- a/blocks/example/example.js
+++ b/blocks/example/example.js
@@ -55,6 +55,7 @@ export function createMediaContainers(el) {
           const rowC = createTag('div', { class: 'descr-details-gray-row' });
           row.querySelectorAll('td').forEach((td, i) => {
             const txt = headers[i]?.textContent || '';
+            const isTall = /\(?tall\)?/i.test(txt);
             let cls = '';
             if (txt.includes('Y')) {
               cls = 'checkmark';
@@ -67,6 +68,7 @@ export function createMediaContainers(el) {
             } else if (txt.includes('i')) {
               cls = 'infomark';
             }
+            if (isTall) cls += ' tall-example';
             const hasMedia = td.querySelector('picture, .video-holder, video');
             if (hasMedia) {
               const cell = createTag('div', {


### PR DESCRIPTION


before / after:
- before: https://main--moderation--adobecom.aem.page/legal-content/qr-codes
- before: https://example-tall--moderation--adobecom.aem.page/legal-content/qr-codes


How to: Add (Tall) to the media cell, for example X (Tall) or Y (Tall)